### PR TITLE
fix off-by-one error in grades

### DIFF
--- a/src/kilterbench/benchmarks.py
+++ b/src/kilterbench/benchmarks.py
@@ -148,7 +148,7 @@ def get_benchmarks(
             params, index=popular.index, columns=["shape", "loc", "scale"]
         )
 
-    grades_df = session.difficulty_grades
+    grades_df = session.difficulty_grades.set_index("difficulty")
     params_df["mode"] = params_df.apply(lambda p: skewnorm_mode(*p), axis=1)
     joined = popular.join(params_df)
     joined = joined.join(


### PR DESCRIPTION
It was of course an off-by-one error! Difficulty is 1-based indexed, so ensure we're using the correct indexing instead of 0-based default.

closes #2 